### PR TITLE
Added command-line arguments

### DIFF
--- a/CRISpy_v1.py
+++ b/CRISpy_v1.py
@@ -36,7 +36,7 @@ def get_parameters():
     prev = ""
     for a in args:
         if prev == "-id":
-            UD = a
+            ID = a
             prev = ""
         elif prev == "-ref":
             ref_seq = str.upper(a)
@@ -68,8 +68,8 @@ column contains the test name, the second column contains the test sequence."""
     with open(filename, "r") as f:
         c = csv.reader(f, delimiter='\t')
         for line in c:
-            tl.append(c[0])
-            tl.append(str.upper(c[1]))
+            tl.append(line[0])
+            tl.append(str.upper(line[1]))
     return tl
 
 def usage():
@@ -189,7 +189,7 @@ def search_fastq(ID,ref_seq,seq_start,seq_end,fastq_files,test_list):
 
     print "Program Running"
 
-    for each_fastq_file in glob.glob(fastq_files):   #For each clone (really each fastq file in directory), open the file as "clone"
+    for each_fastq_file in fastq_files:   #For each clone (really each fastq file in directory), open the file as "clone"
         c_Counter = 0                     #Reset control counter to 0, this counter counts how many times both seq_start and seq_end are found in a line.
         start_counter = 0                  #How many times seq_start is found in a fastq file, used for SNP check
         end_counter = 0                    #How many times seq_end is found in a fastq file, used for SNP check

--- a/CRISpy_v1.py
+++ b/CRISpy_v1.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from __future__ import division
 import os
 import glob
@@ -26,9 +28,63 @@ def get_parameters():
                str('g6'),   str.upper('CCGAGGAGTCCGGCCCGGAAGAG'),
                 ]
 
+    # Command-line argument parsing, added by ariva@ufl.edu
+    cmdline_fastqs = []
+    args = sys.argv[1:]
+    if "-h" in args or "--help" in args:
+        usage()
+    prev = ""
+    for a in args:
+        if prev == "-id":
+            UD = a
+            prev = ""
+        elif prev == "-ref":
+            ref_seq = str.upper(a)
+            prev = ""
+        elif prev == "-start":
+            seq_start = str.upper(a)
+            prev = ""
+        elif prev == "-end":
+            seq_end = str.upper(a)
+            prev = ""
+        elif prev == "-test":
+            test_list = read_test_list(a)
+            prev = ""
+        elif a in ["-id", "-ref", "-start", "-end", "-test"]:
+            prev = a
+        else:
+            cmdline_fastqs.append(a)
+    if cmdline_fastqs:
+        fastq_files = cmdline_fastqs
+    # End additions
+    
     return ID,ref_seq,seq_start,seq_end,fastq_files,test_list
 
+# Added by ariva@ufl.edu
+def read_test_list(filename):
+    """Read the test_list from a tab-delimited file `filename'. The first
+column contains the test name, the second column contains the test sequence."""
+    tl = []
+    with open(filename, "r") as f:
+        c = csv.reader(f, delimiter='\t')
+        for line in c:
+            tl.append(c[0])
+            tl.append(str.upper(c[1]))
+    return tl
 
+def usage():
+    sys.stdout.write("""CRIS.py [options] fastqs...
+
+Where options are:
+  -id  I   | Set run ID to I
+  -ref R   | Set reference sequence to R
+  -start S | Set start sequence to S
+  -end E   | Set end sequence to E
+  -test T  | Read test list from tab-delimited file T
+
+""")
+    sys.exit(0)
+    
 def pairwise(iterable):
     #Make an ordered dictionary from items in in test list
     "s -> (s0, s1), (s2, s3), (s4, s5), ..."

--- a/CRISpy_v1.py
+++ b/CRISpy_v1.py
@@ -35,22 +35,22 @@ def get_parameters():
         usage()
     prev = ""
     for a in args:
-        if prev == "-id":
+        if prev in ["-i", "--id"]:
             ID = a
             prev = ""
-        elif prev == "-ref":
+        elif prev == ["-r", "--ref"]:
             ref_seq = str.upper(a)
             prev = ""
-        elif prev == "-start":
+        elif prev == ["-s", "--start"]:
             seq_start = str.upper(a)
             prev = ""
-        elif prev == "-end":
+        elif prev == ["-e", "--end"]:
             seq_end = str.upper(a)
             prev = ""
-        elif prev == "-test":
+        elif prev == ["-t", "--test"]:
             test_list = read_test_list(a)
             prev = ""
-        elif a in ["-id", "-ref", "-start", "-end", "-test"]:
+        elif a in ["-i", "--id", "-r", "--ref", "-s", "--start", "-e", "--end", "-t", "--test"]:
             prev = a
         else:
             cmdline_fastqs.append(a)
@@ -75,12 +75,16 @@ column contains the test name, the second column contains the test sequence."""
 def usage():
     sys.stdout.write("""CRIS.py [options] fastqs...
 
-Where options are:
-  -id  I   | Set run ID to I
-  -ref R   | Set reference sequence to R
-  -start S | Set start sequence to S
-  -end E   | Set end sequence to E
-  -test T  | Read test list from tab-delimited file T
+Where options are (short form followed by long form):
+  -h   | --help    | Display this help message.
+  -i I | --id I    | Set run ID to I.
+  -r R | --ref R   | Set reference sequence to R.
+  -s S | --start S | Set start sequence to S.
+  -e E | --end E   | Set end sequence to E.
+  -t T | --test T  | Read test list from tab-delimited file T.
+
+The tab-delimited file passed as the value of `-t' should have two columns,
+containing the test name and test sequence respectively.
 
 """)
     sys.exit(0)

--- a/CRISpy_v1.py
+++ b/CRISpy_v1.py
@@ -56,6 +56,8 @@ def get_parameters():
             cmdline_fastqs.append(a)
     if cmdline_fastqs:
         fastq_files = cmdline_fastqs
+    else:
+        fastq_files = glob.glob(fastq_files)
     # End additions
     
     return ID,ref_seq,seq_start,seq_end,fastq_files,test_list

--- a/Readme.md
+++ b/Readme.md
@@ -44,10 +44,24 @@ CRISpy_v1.py [options] fastqs...
 ```
 
 The following table lists the available command-line options with the corresponding parameter name.
+Options have both a short and a long form (e.g., -i and --id) which can be used interchangeably.
 
-Argument | Parameter | Description
----------|-----------|------------
--id      | ID        | Identifier for this analysis
+Option | Long form | Parameter | Description
+-------|-----------|-----------|------------
+-i I   | --id I    | ID        | Set run ID to I
+-r R   | --ref R   | ref_seq   | Set reference sequence to R
+-s S   | --start S | seq_start | Set start sequence to S
+-e E   | --end E   | seq_end   | Set end sequence to E
+-t T   | --test T  | test_list | Read test list from tab-delimited file T
+
+The tab-delimited file specified with -t should have two columns, containing test name and test
+sequence respectively. For example:
+
+```
+g10	GAGGCAGGCGTCGAAGAGTACGG
+g14	CGGCCCTGAAGAAGACGGCGGGG
+g6	CCGAGGAGTCCGGCCCGGAAGAG
+```
 
 ## Output
 A folder is created in the working directory with the name 'ID' from step 1.

--- a/Readme.md
+++ b/Readme.md
@@ -48,6 +48,7 @@ Options have both a short and a long form (e.g., -i and --id) which can be used 
 
 Option | Long form | Parameter | Description
 -------|-----------|-----------|------------
+-h     | --help    |           | Display help message
 -i I   | --id I    | ID        | Set run ID to I
 -r R   | --ref R   | ref_seq   | Set reference sequence to R
 -s S   | --start S | seq_start | Set start sequence to S

--- a/Readme.md
+++ b/Readme.md
@@ -35,6 +35,20 @@ Check the printed 'Working directory' and verify that is where your fastq files 
 
 Check results in newly created folder that has the same label as "ID".
 
+## Command-line usage
+
+Parameters can also be passed on the command-line; this avoids the need to edit the script itself, and allows the script to be included in automated analysis pipelines. In this case the syntax of the command is:
+
+```
+CRISpy_v1.py [options] fastqs...
+```
+
+The following table lists the available command-line options with the corresponding parameter name.
+
+Argument | Parameter | Description
+---------|-----------|------------
+-id      | ID        | Identifier for this analysis
+
 ## Output
 A folder is created in the working directory with the name 'ID' from step 1.
 In the folder are two files:  

--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ An easy method to install Python 2.7 and Pandas is through:
 
 ## Usage
 
-To use CRIS.py, directly modify the file CRIS.py in the Python editor.
+To use CRIS.py, directly modify the file CRIS.py in the Python editor (or use command-line options as described in the next section).
 Change text between quote (') marks to reflect your target amplicon.  CRIS.py reads DNA as a simple text sequence.  Therefore all DNA sequences entered must be on the same strand.
 Parameters to modify are:
   1.  ID:   The name of the project, gRNA or gene.  This will be used to create the output folder.


### PR DESCRIPTION
I added support for command-line arguments, so user can specify the values for ref_seq, seq_start, seq_end, etc on the command line instead of having to modify the script. The changes are totally backward-compatible, ie if no arguments are specified, the program will work exactly as before. Thanks!